### PR TITLE
Fix syntax error in PHP 7.1

### DIFF
--- a/src/AspectMock/Kernel.php
+++ b/src/AspectMock/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends AspectKernel
             $options['excludePaths'] = [];
         }
         $options['debug'] = true;
+        $options['excludePaths'] = [];
         $options['excludePaths'][] = __DIR__;
 
         parent::init($options);


### PR DESCRIPTION
[] operator not supported for strings